### PR TITLE
chore(build): use setuptools instead of obsolete distutils

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: "Build sdist"
         run: |
+          pip3 install pipx ppsetuptools
           pipx run build --sdist
 
       - name: "Upload build artifacts"

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ examples/tree_N=10000_r=0.0_L=1000_s=0.01.pdf
 examples/tree_N=200_r=0.0_L=1000_U=0.1_s=-1e-06.pdf
 
 examples/*.png
+
+/\.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -euxo pipefail >/dev/null \
   bison \
   build-essential \
   ca-certificates \
+  ccache \
   curl \
   git \
   gsl-bin \
@@ -23,10 +24,7 @@ RUN set -euxo pipefail >/dev/null \
   parallel \
   python3 \
   python3-dev \
-  python3-distutils \
   python3-pip \
-  python3-setuptools \
-  python3-wheel \
   sudo \
   time \
 >/dev/null \

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@
 #			PLATFORM-DEPENDENT OPTIONS			   #
 #									   #
 ############################################################################
-# Please set your Python 2.7 executable if you want to build the Python
+# Please set your Python 3 executable if you want to build the Python
 # bindings. If you are only interested in the C++ part of the library,
 # comment out the following line
-PYTHON := python3 -W ignore::DeprecationWarning
+PYTHON := python3
 
 # Note: please look in 'setup.py' if you are building the Python extension!
 #       You can call distutils with 'setup.py' directly if you prefer. The
@@ -284,11 +284,10 @@ SOMODULE := $(SWIG_MODULE:%.i=_%.so)
 
 # Recipes
 python: $(PYBDIR)/$(SWIG_WRAP) $(PYBDIR)/$(PYMODULE) $(SOURCES:%=$(SRCDIR)/%) $(DISTUTILS_SETUP)
-	mkdir -p $(PKGDIR)/python
-	$(PYTHON) setup.py clean --all
-	$(PYTHON) setup.py install --install-lib=$(PYBDIR)
-	$(PYTHON) setup.py install --install-lib=$(PKGDIR)/python
-	$(PYTHON) setup.py clean
+	rm -rf $(PKGDIR)/python
+	$(PYTHON) setup.py install --single-version-externally-managed --root=. --install-lib=$(PKGDIR)/python
+	cp src/python/FFPopSim.py $(PKGDIR)/python/
+	rm -rf *.egg-info $(PKGDIR)/python/*.egg-info
 
 python-install:
 	$(PYTHON) setup.py install --skip-build --install-lib=$(PKGDIR)/python

--- a/docker-dev
+++ b/docker-dev
@@ -84,6 +84,9 @@ ${NICE} docker run -it --rm \
   --user="$(id -u):$(id -g)" \
   --volume="${PROJECT_ROOT_DIR}:/workdir" \
   --workdir="/workdir/${PACKAGE_DIR_REL}" \
+  --env="CC=ccache gcc" \
+  --env="CXX=ccache g++" \
+  --env="CCACHE_DIR=.cache/ccache" \
   --env="UID=$(id -u)" \
   --env="GID=$(id -g)" \
   --env="USER=${USER}" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,32 @@
+[project]
+name = "FFPopSim"
+version = "3.0.0"
+description = "Simulate large populations that are polymorphic at many loci"
+authors = [
+  { name = "Fabio Zanini", email = "fabio.zanini@tuebingen.mpg.de" },
+  { name = "Richard Neher", email = "richard.neher@tuebingen.mpg.de" },
+]
+readme = "README.md"
+requires-python = ">=3.6"
+keywords = ["packaging", "dependency", "infer", "pyproject.toml"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: C++",
+  "License :: OSI Approved :: GPL3",
+  "Operating System :: OS Independent",
+  "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+[project.urls]
+homepage = "https://github.com/neherlab/ffpopsim"
+documentation = "https://readthedocs.org/projects/ffpopsim"
+repository = "https://github.com/neherlab/ffpopsim"
+
+
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = [
   "numpy",
+  "ppsetuptools",
   "setuptools",
   "wheel",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,8 @@ matplotlib==3.6.0
 notebook==6.5.1
 numpy==1.23.4
 pandas==1.5.1
+ppsetuptools
 scipy==1.9.3
 seaborn==0.12.1
+setuptools
+wheel

--- a/scripts/release
+++ b/scripts/release
@@ -46,7 +46,7 @@ if [ "${branch}" != "master" ] && [ "${branch}" != "main" ] ; then
 fi
 
 printf "\n * Bumping version"
-sed -i'' "s|VERSION = '.*'|VERSION = '${version}'|g" setup.py
+sed -i'' "s|version = '.*'|version = '${version}'|g" pyproject.toml
 
 if [ -z "$(git status -s)" ]; then
   echo "Version bump had no effect. Double-check that the version number you are providing is correct and is not the same as the current version." >/dev/stderr

--- a/setup.py
+++ b/setup.py
@@ -1,88 +1,36 @@
+#!/usr/bin/env python
 # vim: fdm=indent
-'''
-author:     Richard Neher, Fabio Zanini
-date:       23/08/12
-license:    GPL3
-content:    Distutils setup script for the Python bindings of FFPopSim.
 
-            If your compiler has problems finding GSL and/or BOOST and you are
-            sure they are installed on your system, check the section
-            PLATFORM-DEPENDENT OPTIONS below.
+import sys
 
-            *Note*: this file is called by the Makefile with the command
+# Python 3.6 compatibility: Python 3.6 has no compatible version of setuptools that supports
+# PEP-517 (the `pyproject.toml`-based config), so we use a shim package `ppsetuptools` instead.
+if sys.version_info >= (3, 7):
+  from setuptools import setup, Extension
+else:
+  from ppsetuptools import setup, Extension
 
-                python setup.py build_ext
-            
-            to build the C++/Python extension. It can, however, also be called
-            directly including with other commands such as
+import numpy as np
 
-                python setup.py install
-
-            to install the Python bindings of FFPopSim on the system. Note that
-            calling this file directly does not clean the 'build' folder.
-'''
-from distutils.core import setup, Extension
-from numpy import distutils as npdis
-
-############################################################################
-#									   #
-#			PLATFORM-DEPENDENT OPTIONS			   #
-#									   #
-############################################################################
-# Please add your include folders to the following list, where the compiler
-# can find GSL, BOOST, and Python 2.7 headers.
-includes = ['/usr/include', '/usr/local/include', '/opt/local/include']
-
-# Please add your shared library folders to the following list, where the linker
-# can find GSL and Python 2.X
-library_dirs = []
-
-############################################################################
-#                !!  DO NOT EDIT BELOW THIS LINE  !!                       #
-############################################################################
-VERSION = '3.0.0'
-SRCDIR = 'src'
-PYBDIR = SRCDIR+'/python'
-
-includes = includes + npdis.misc_util.get_numpy_include_dirs()
-libs = ['gsl', 'gslcblas']
-
-# Auxiliary functions
-def read(fname):
-    import os
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-
-# Setup
-setup(name='FFPopSim',
-      author='Fabio Zanini, Richard Neher',
-      author_email='fabio.zanini@tuebingen.mpg.de, richard.neher@tuebingen.mpg.de',
-      description='C++/Python library for population genetics.',
-      long_description=read('README.md'),
-      license='GPL3',
-      url='http://webdav.tuebingen.mpg.de/ffpopsim/',
-
-      version=VERSION,
-      package_dir={'': PYBDIR},
-
-      # This is the pure Python file
-      py_modules=['FFPopSim'],
-
-      # This is the C++ extension
-      ext_modules=[Extension('_FFPopSim',
-                             sources=[PYBDIR+'/FFPopSim_wrap.cpp',
-                                      SRCDIR+'/haploid_highd.cpp', 
-                                      SRCDIR+'/haploid_lowd.cpp', 
-                                      SRCDIR+'/hivpopulation.cpp',
-                                      SRCDIR+'/hivgene.cpp',
-                                      SRCDIR+'/rootedTree.cpp',
-                                      SRCDIR+'/multiLocusGenealogy.cpp',
-                                      SRCDIR+'/hypercube_lowd.cpp', 
-                                      SRCDIR+'/hypercube_highd.cpp'],
-                             include_dirs=includes, 
-                             library_dirs=library_dirs,
-                             libraries=libs,
-                            ),
-                  ]
-      )
-
+setup_args = dict(
+  ext_modules = [
+    Extension(
+      '_FFPopSim',
+      [
+        'src/python/FFPopSim_wrap.cpp',
+        'src/haploid_highd.cpp',
+        'src/haploid_lowd.cpp',
+        'src/hivpopulation.cpp',
+        'src/hivgene.cpp',
+        'src/rootedTree.cpp',
+        'src/multiLocusGenealogy.cpp',
+        'src/hypercube_lowd.cpp',
+        'src/hypercube_highd.cpp',
+      ],
+      include_dirs=[np.get_include()],
+      libraries=['gsl', 'gslcblas'],
+      py_limited_api = True
+    )
+  ]
+)
+setup(**setup_args)


### PR DESCRIPTION
The [distutils package is deprecated](https://peps.python.org/pep-0632/) and will be removed in Python 3.12. In practice it is hard to reliably build distutils packages for multiple python versions, so let's upgrade to setuptools + PEP-517 + PEP-518 workflow (using `pyproject.toml`) [[1](https://setuptools.pypa.io/en/latest/build_meta.html)][[2](https://peps.python.org/pep-0517/)][[3](https://peps.python.org/pep-0518/)].