### PR TITLE
fix: expose sampled_leafs property

### DIFF
--- a/src/ffpopsim_highd.h
+++ b/src/ffpopsim_highd.h
@@ -337,6 +337,8 @@ public:
         // construct subtrees
 	int construct_subtree(vector <tree_key_t> subtree_leafs, rooted_tree &other);
 
+	vector <tree_key_t> get_sampled_leafs() const { return sampled_leafs; }
+	void set_sampled_leafs(const vector <tree_key_t>& leafs) { sampled_leafs = leafs; }
 private:
 	static int parse_label(std::string label, int *index, int *clone_size, int *branch_length);
 	int parse_subtree(tree_key_t &parent_key, std::string &tree_s);

--- a/src/python/ffpopsim_highd.i
+++ b/src/python/ffpopsim_highd.i
@@ -505,6 +505,19 @@ def leafs(self, leaves):
     self._leafs = vector_tree_key(leaves)
 %}
 
+%rename (_sampled_leafs) sampled_leafs;
+%pythoncode
+%{
+@property
+def sampled_leafs(self):
+    return list(self._sampled_leafs)
+
+
+@leafs.setter
+def sampled_leafs(self, leaves):
+    self._sampled_leafs = vector_tree_key(leaves)
+%}
+
 %pythoncode
 %{
 def to_Biopython_tree(self):


### PR DESCRIPTION
Newer Swig versions don't expose C++ class fields it seems, so let's expose the required property explicitly.