### PR TITLE
fix: reduce pollution of global namespace

### DIFF
--- a/src/ffpopsim_generic.h
+++ b/src/ffpopsim_generic.h
@@ -1,8 +1,8 @@
 /**
  * @file popgen.h
- * @brief Header file with the classes and types provided with the library. 
+ * @brief Header file with the classes and types provided with the library.
  * @author Richard Neher, Fabio Zanini
- * @version 
+ * @version
  * @date 2010-10-27
  * Copyright (c) 2012-2013, Richard Neher, Fabio Zanini
  * All rights reserved.
@@ -49,7 +49,10 @@
 #define CROSSOVERS 2
 #define SINGLE_CROSSOVER 3
 
-using namespace std;
+using std::list;
+using std::map;
+using std::string;
+using std::vector;
 
 /**
  * @brief Pairs of an index and a value
@@ -82,7 +85,7 @@ struct stat_t {
 
 /**
  * @brief Sample of any scalar property.
- * 
+ *
  * This class is used to store samples of scalar quantities used in the evolution of the population,
  * for instance fitness or allele frequencies. I enables simple manipulations (mean, variance, etc.).
  */
@@ -110,7 +113,7 @@ public:
 	int calc_mean();
 	int calc_variance();
 	int calc_distribution();
-	int print_distribution(ostream &out);
+	int print_distribution(std::ostream &out);
 };
 
 #endif /* FFPOPGEN_GENERIC_H_ */

--- a/src/ffpopsim_generic.h
+++ b/src/ffpopsim_generic.h
@@ -28,6 +28,7 @@
 #include <time.h>
 #include <cmath>
 #include <vector>
+#include <map>
 #include <bitset>
 #include <string>
 #include <sstream>

--- a/src/ffpopsim_highd.h
+++ b/src/ffpopsim_highd.h
@@ -37,8 +37,14 @@
 #define HCF_VERBOSE 0
 #define WORDLENGTH 28 	//length used to chop bitsets into words
 
-using namespace std;
-
+using std::cerr;
+using std::endl;
+using std::istream;
+using std::list;
+using std::map;
+using std::ostream;
+using std::string;
+using std::vector;
 
 /**
  * @brief Trait coefficient for a set of loci.
@@ -225,8 +231,6 @@ struct clone_t {
 #include <sstream>
 #include <list>
 #include <gsl/gsl_histogram.h>
-
-using namespace std;
 
 struct tree_key_t {
 	int index;

--- a/src/ffpopsim_lowd.h
+++ b/src/ffpopsim_lowd.h
@@ -2,7 +2,7 @@
  * @file popgen_lowd.h
  * @brief Header file for low-dimensional simulations
  * @author Richard Neher, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-04-19
  *
  * Copyright (c) 2012-2013, Richard Neher,Fabio Zanini
@@ -32,7 +32,10 @@
 #define HC_COEFF -1			//hypercube_lowd.coeff is up-to-date
 #define HC_FUNC_EQ_COEFF 0		//hypercube_lowd.func equal hypercube_lowd.coeff
 
-using namespace std;
+using std::list;
+using std::map;
+using std::string;
+using std::vector;
 
 /**
  * @brief Binary hypercube_lowd used in low-dimensional simulations.
@@ -76,11 +79,11 @@ public:
 	void set_state(int s){state=s;}
 
 	//in and out
-	int read_coeff(istream &in);
-	int write_func(ostream &out);
-	int write_coeff(ostream &in,  bool label=false);
-	int read_func(istream &out);
-	int read_func_labeled(istream &in);
+	int read_coeff(std::istream &in);
+	int write_func(std::ostream &out);
+	int write_coeff(std::ostream &in,  bool label=false);
+	int read_func(std::istream &out);
+	int read_func_labeled(std::istream &in);
 
 	//analysis
 	int signature(int point);
@@ -189,7 +192,7 @@ public:
 
 	// genotype readout
 	double get_genotype_frequency(int genotype){return population.get_func(genotype);}
-	
+
 	// allele frequencies
 	double get_allele_frequency(int locus){return 0.5 * (1 + get_chi(locus));}
 	double get_pair_frequency(int locus1, int locus2){return 0.25 * (get_moment(locus1, locus2) - 1) + 0.5 * (get_allele_frequency(locus1) + get_allele_frequency(locus2));}

--- a/src/haploid_highd.cpp
+++ b/src/haploid_highd.cpp
@@ -29,6 +29,23 @@
 #include <math.h>
 #include "ffpopsim_highd.h"
 
+using std::cerr;
+using std::endl;
+using std::ifstream;
+using std::ios;
+using std::istream;
+using std::list;
+using std::map;
+using std::max;
+using std::max_element;
+using std::min;
+using std::min_element;
+using std::ofstream;
+using std::ostream;
+using std::setw;
+using std::string;
+using std::vector;
+
 /* Initialize the number of instances to zero */
 size_t haploid_highd::number_of_instances = 0;
 

--- a/src/hypercube_highd.cpp
+++ b/src/hypercube_highd.cpp
@@ -23,6 +23,19 @@
  */
 #include "ffpopsim_highd.h"
 
+using std::cerr;
+using std::endl;
+using std::ifstream;
+using std::ios;
+using std::istream;
+using std::list;
+using std::map;
+using std::ofstream;
+using std::ostream;
+using std::setw;
+using std::string;
+using std::vector;
+
 hypercube_highd::hypercube_highd()
 {
 mem=false;

--- a/src/hypercube_lowd.cpp
+++ b/src/hypercube_lowd.cpp
@@ -22,6 +22,19 @@
  */
 #include "ffpopsim_lowd.h"
 
+using std::cerr;
+using std::endl;
+using std::ifstream;
+using std::ios;
+using std::istream;
+using std::list;
+using std::map;
+using std::ofstream;
+using std::ostream;
+using std::setw;
+using std::string;
+using std::vector;
+
 //default constructor
 hypercube_lowd::hypercube_lowd() {
 	mem=false;

--- a/src/rootedTree.cpp
+++ b/src/rootedTree.cpp
@@ -24,6 +24,12 @@
  */
 
 #include "ffpopsim_highd.h"
+
+using std::map;
+using std::pair;
+using std::set;
+using std::stringstream;
+
 /*
  * this overloads the ostream operator to output keys of nodes and edges
  */

--- a/src/sample.cpp
+++ b/src/sample.cpp
@@ -43,7 +43,7 @@ int sample::set_up(int n)
 {
 	if (n<1)
 	{
-		cerr <<"sample::set_up(): number of values has to be greater than zero! Got: "<<bins<<endl;
+		std::cerr <<"sample::set_up(): number of values has to be greater than zero! Got: "<<bins<<std::endl;
 		return SAMPLE_ERROR;
 	}
 	else
@@ -59,7 +59,7 @@ int sample::set_distribution(int bins_in)
 {
 	if (bins_in<1)
 	{
-		cerr <<"sample::set_distribution(): number of bins has to be greater than zero! Got: "<<bins<<endl;
+		std::cerr <<"sample::set_distribution(): number of bins has to be greater than zero! Got: "<<bins<<std::endl;
 		return SAMPLE_ERROR;
 	}
 	else
@@ -75,7 +75,7 @@ int sample::calc_mean()
 	double v;
 	if (mem_values==false)
 	{
-		cerr <<"sample::calc_mean(): Set values first!"<<endl;
+		std::cerr <<"sample::calc_mean(): Set values first!"<<std::endl;
 		return SAMPLE_ERROR;
 	}
 	mean=0;
@@ -97,7 +97,7 @@ int sample::calc_variance()
 	double v;
 	if (mem_values==false)
 	{
-		cerr <<"sample::calc_variance(): Set values first!"<<endl;
+		std::cerr <<"sample::calc_variance(): Set values first!"<<std::endl;
 		return SAMPLE_ERROR;
 	}
 	calc_mean();
@@ -120,7 +120,7 @@ int sample::calc_distribution()
 {
 	if (mem_values==false)
 	{
-		cerr <<"sample::calc_distribution(): Set values first!"<<endl;
+		std::cerr <<"sample::calc_distribution(): Set values first!"<<std::endl;
 		return SAMPLE_ERROR;
 	}
 	double min=values[0], max=values[0];
@@ -146,16 +146,16 @@ int sample::calc_distribution()
 }
 
 //print allele frequencies to stream
-int sample::print_distribution(ostream &out)
+int sample::print_distribution(std::ostream &out)
 {
 	if (out.bad())
 	{
-		cerr <<"sample::print_distribution(): bad stream\n";
+		std::cerr <<"sample::print_distribution(): bad stream\n";
 		return SAMPLE_ERROR;
 	}
 	calc_distribution();
-	for (int l=0; l<bins; l++) out <<setw(15)<<gsl_histogram_get(distribution, l);
-	out <<endl;
+	for (int l=0; l<bins; l++) out <<std::setw(15)<<gsl_histogram_get(distribution, l);
+	out <<std::endl;
 	return 0;
 }
 

--- a/tests/highd.cpp
+++ b/tests/highd.cpp
@@ -2,7 +2,7 @@
  * @file highd.cpp
  * @brief Tests for the high-dimensional simulation library.
  * @author Richard Neher, Boris Shraiman, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-04-20
  */
 
@@ -13,6 +13,10 @@
 
 /* Be verbose? */
 #define HIGHD_VERBOSE 1
+
+using std::cerr;
+using std::cout;
+using std::endl;
 
 /* Test generic library access */
 int library_access() {
@@ -37,7 +41,7 @@ int library_access() {
 int sample_initialize() {
 	int N = 5;
 
-	sample sam;
+	::sample sam;
 	sam.set_up(N);
 
 	for(int i=0; i< N; i++)
@@ -75,8 +79,8 @@ int hc_setting() {
 		loci.assign(1, myints[i]);
 		hc.add_coefficient(values[i], loci);
 		loci.clear();
-	}	
-	
+	}
+
 	if(HIGHD_VERBOSE){
 		cerr<<"Coefficient indices and values: ";
 		for(int i=0; i<4; i++) {
@@ -93,8 +97,8 @@ int pop_initialize() {
 
 	haploid_highd pop(L, 3, 1);
 	if(HIGHD_VERBOSE)
-		cerr<<"L = "<<pop.get_number_of_loci()<<endl;	
-	return 0;	
+		cerr<<"L = "<<pop.get_number_of_loci()<<endl;
+	return 0;
 }
 
 /* Test evolution */
@@ -142,7 +146,7 @@ int pop_evolve() {
 		cerr<<"Fitness mean and variance: "<<fitness.mean<<", "<<fitness.variance<<endl;
 	}
 
-	return 0;	
+	return 0;
 }
 
 

--- a/tests/hivpopulation.cpp
+++ b/tests/hivpopulation.cpp
@@ -2,7 +2,7 @@
  * @file highd.cpp
  * @brief Tests for the high-dimensional simulation library.
  * @author Richard Neher, Boris Shraiman, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-04-20
  */
 
@@ -13,6 +13,11 @@
 
 /* Be verbose? */
 #define HIV_VERBOSE 1
+
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::ifstream;
 
 /* Test end-user subclass initialization */
 int hiv_initialize() {

--- a/tests/lowd.cpp
+++ b/tests/lowd.cpp
@@ -2,7 +2,7 @@
  * @file lowd.cpp
  * @brief Tests for the low-dimensional simulation library.
  * @author Richard Neher, Boris Shraiman, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-04-20
  */
 /* Include directives */
@@ -13,6 +13,10 @@
 
 /* Be verbose? */
 #define LOWD_VERBOSE 1
+
+using std::cerr;
+using std::cout;
+using std::endl;
 
 /* Test generic library access */
 int library_access() {
@@ -32,7 +36,7 @@ int library_access() {
 int sample_initialize() {
 	int N = 5;
 
-	sample sam;
+	::sample sam;
 	sam.set_up(N);
 
 	for(int i=0; i< N; i++)
@@ -66,7 +70,7 @@ int hc_setting() {
 	hc.reset();
 	hc.additive(additive);
 	hc.fft_coeff_to_func();
-	
+
 	if(LOWD_VERBOSE){
 		cerr<<"Func values: ";
 		for(int gt=0; gt < (1<<L); gt++)
@@ -87,8 +91,8 @@ int pop_initialize() {
 
 	haploid_lowd pop(L, 3);
 	if(LOWD_VERBOSE)
-		cerr<<"L = "<<pop.L()<<endl;	
-	return 0;	
+		cerr<<"L = "<<pop.L()<<endl;
+	return 0;
 }
 
 /* Test evolution from allele frequencies */
@@ -108,14 +112,14 @@ int pop_evolve_af() {
 	double* rr = new double[L-1];
 	for(int i=0; i < L-1; i++)
 		rr[i] = 0.01;
-	pop.set_recombination_rates(rr);	
+	pop.set_recombination_rates(rr);
 	pop.set_mutation_rates(1e-2);
 	pop.evolve(5);
 
 	if(LOWD_VERBOSE) {
 		cerr<<"Population size: "<<pop.N()<<endl;
 	}
-	return 0;	
+	return 0;
 }
 
 /* Test evolution from genotype frequencies */
@@ -136,14 +140,14 @@ int pop_evolve_gf() {
 	double* rr = new double[L-1];
 	for(int i=0; i < L-1; i++)
 		rr[i] = 0.01;
-	pop.set_recombination_rates(rr);	
+	pop.set_recombination_rates(rr);
 	pop.set_mutation_rates(1e-2);
 	pop.evolve(5);
 
 	if(LOWD_VERBOSE) {
 		cerr<<"Population size: "<<pop.N()<<endl;
 	}
-	return 0;	
+	return 0;
 }
 
 
@@ -166,7 +170,7 @@ int pop_observables() {
 
 	}
 
-	return 0;	
+	return 0;
 }
 
 /* MAIN */

--- a/tests/recombination_lowd.cpp
+++ b/tests/recombination_lowd.cpp
@@ -2,7 +2,7 @@
  * @file recombination_lowd.cpp
  * @brief Test recombination routine for haploid_lowd
  * @author Richard Neher, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-08-28
  *
  * Tests for the recombination routine in haploid_lowd are performed,
@@ -16,6 +16,12 @@
 
 /* Be verbose? */
 #define LOWD_VERBOSE 1
+
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::ifstream;
+using std::setw;
 
 /* Declaration */
 class haploid_lowd_test : public haploid_lowd {
@@ -98,11 +104,11 @@ int haploid_lowd_test::test_recombinant_distribution(){
 
 				// print debugging info
 				for (int locus=number_of_loci - 1; locus >= 0; locus--) {
-					cout<<((rec_pattern&(1<<locus))?1:0);	
+					cout<<((rec_pattern&(1<<locus))?1:0);
 				}
 				cout<<"\t"<<rec_pattern<<endl;
 				for (int locus=0; locus<number_of_loci-1; locus++) {
-					cout<<(locus<=crossover_point?" ":(locus==(crossover_point+1)?"|":" "));					
+					cout<<(locus<=crossover_point?" ":(locus==(crossover_point+1)?"|":" "));
 				}
 				cout<<endl<<endl;
 
@@ -328,7 +334,7 @@ int haploid_lowd_test::test_single_crossover_set_rates() {
 			for(int i=0; i < set_size; i++) cout<<((i <= locus)?1:0);
 			cout<<"\t"<<recombination_patterns[subset][locus]<<endl;
 			for(int i=0; i < set_size; i++) cout<<ii[i];
-				
+
 			cout<<endl<<endl;
 		}
 	}

--- a/tests/test_genealogy.cpp
+++ b/tests/test_genealogy.cpp
@@ -2,7 +2,7 @@
  * @file test_genealogies.cpp
  * @brief Tests for the genealogies in the high-dimensional simulation library.
  * @author Richard Neher, Boris Shraiman, Fabio Zanini
- * @version 
+ * @version
  * @date 2012-04-20
  */
 
@@ -13,6 +13,11 @@
 
 /* Be verbose? */
 #define HIGHD_VERBOSE 1
+
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::ifstream;
 
 // test neutral evolution
 int kingman_coalescent() {


### PR DESCRIPTION
`using namespace std` directive brings `std::sample` on newer compilers into global state and it collides with `sample` identifiers in tests.

Here I remove `using namespace std` and add `using` directives only for things that are needed, thus resolcing the name collisions.